### PR TITLE
Fixed compilation error on Visual Studio 2013

### DIFF
--- a/include/Infectorpp/InfectorContainer.hpp
+++ b/include/Infectorpp/InfectorContainer.hpp
@@ -113,8 +113,12 @@ void Container::wire(){
 
 	isWireable< Impl>(); //compile time test
 
-    priv::TypeInfoP types[ sizeof...( SmartPointers)]
-                        { &typeid(typename SmartPointers::type)... };
+	// -this is to fix a VS bug. Feel free to raise the limit
+	static_assert(sizeof...(SmartPointers) <= 6,
+		"Unable to wire more than 6 dependencies");
+
+	priv::TypeInfoP types[6]
+		{ &typeid(typename SmartPointers::type)... };
 						
 	container->wire( &typeid(Impl), types, sizeof...( SmartPointers),
 					 &factoryFunction< Impl, SmartPointers...>,


### PR DESCRIPTION
We are happy of the new framework you developed, so we tested for you on Visual Studio (seems you don't have Win7/Win8)
and fixed the only compilation bug we found). We are overall happy of the new design, looking for a quick first release.
