### PR TITLE
std::is_destructbile not working the same on all compilers

### DIFF
--- a/include/Infectorpp/InfectorTraits.hpp
+++ b/include/Infectorpp/InfectorTraits.hpp
@@ -27,12 +27,6 @@ void isMultiBaseVariadic(){
     static_assert( std::is_base_of< I, T>::value,
                     "I must be base class for T");
 
-// clang miss "std::is_destructible" :/
-#if defined(__GNUC__) || defined(__GNUG__) || defined(_MSC_VER) 
-	static_assert(  std::is_destructible<T>::value
-				  , " T must be destructible");
-#endif
-
     isMultiBaseVariadic< T, Contracts...>();
 }
 
@@ -55,12 +49,6 @@ void isMultiBase(){
     static_assert(  sizeof...( Contracts)>0 //if no contracts don't use "bind X As"
                       , " There must be at least 1 interface ");
 
-// clang miss "std::is_destructible" :/
-#if defined(__GNUC__) || defined(__GNUG__) || defined(_MSC_VER) 
-	static_assert(  std::is_destructible<T>::value
-				  , " T must be destructible");
-#endif
-
     isMultiBaseVariadic< T, Contracts...>();
 }
 
@@ -81,12 +69,6 @@ void isWireable(){
 				  
 	static_assert( !std::is_base_of< Infector::Context, T>::value
                   , "Cannot wire Infector::Context or its subclasses!");
-
-// clang miss "std::is_destructible" :/
-#if defined(__GNUC__) || defined(__GNUG__) || defined(_MSC_VER) 
-	static_assert(  std::is_destructible<T>::value
-				  , " T must be destructible");
-#endif
 }
 
 


### PR DESCRIPTION
should get rid of it :/ :+1:
